### PR TITLE
Fix #2 and a typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+media/
+files/

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Some additional installations are mentioned below
     sudo apt-get install libcairo2-dev libjpeg-dev libgif-dev 
     sudo apt install texlive-latex-base texlive-full texlive-fonts-extra
 ```
-Phew! This will be the last isntallation for additional python modules. Run this in the terminal 
+Phew! This will be the last installation for additional python modules. Run this in the terminal 
 ``` bash
     python3 -m pip install -r requirements.txt
 ```
@@ -94,7 +94,7 @@ I recommend to look at it later, and start with the tutorial.
 Finally we can start. In this tutorial, we will learn by doing. 
 ### Basics
 ``` python
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class Shapes(Scene):
     def construct(self):
@@ -128,7 +128,7 @@ We will break this into parts:
 ### Shapes
 
 ```python
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from math import cos, sin, pi
 
 class Shapes(Scene):
@@ -213,7 +213,7 @@ There are other bases classes we will explore for making Graphs, 3D Scenes,etc.
 ### Text
 
 ```python
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class makeText(Scene):
     def construct(self):
@@ -254,7 +254,7 @@ TextMobjects will be used later on to write good looking math equations.
 
 ```python
 
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class Equations(Scene):
     def construct(self):
@@ -354,7 +354,7 @@ second_eq = ["$J(\\theta_{0}, \\theta_{1})$", "=", "$\\frac{1}{2m}$", "$\\sum\\l
 ### Graphing
 
 ```python
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 import math
 
 class Graphing(GraphScene):
@@ -446,7 +446,7 @@ CONFIG = {
 ### 3D Graphing
 
 ```python
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class ThreedSurface(ParametricSurface):
 
@@ -496,7 +496,7 @@ A continuation of this tutorial will follow to explain how the camera works. For
 Manim has a mobject made for images. You can resise them, invert their colors, etc by using Manim methods. 
 
 ```python
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class Images(Scene):
     def construct(self):
@@ -512,7 +512,7 @@ class Images(Scene):
 Alternatively, you could load the image using OpenCV or PIL, and then display the image using Manim.
 
 ```python
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 import cv2
 
 class Images(Scene):

--- a/code/basics.py
+++ b/code/basics.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class Shapes(Scene):
     def construct(self):

--- a/code/graphing.py
+++ b/code/graphing.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 import math
 
 class Graphing(GraphScene):

--- a/code/mathEq.py
+++ b/code/mathEq.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class Equations(Scene):
     def construct(self):

--- a/code/shapes.py
+++ b/code/shapes.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 from math import cos, sin, pi
 
 class Shapes(Scene):

--- a/code/text.py
+++ b/code/text.py
@@ -1,4 +1,4 @@
-from big_ol_pile_of_manim_imports import *
+from manimlib.imports import *
 
 class makeText(Scene):
     def construct(self):


### PR DESCRIPTION
* .gitignore: Automatically ignore media/ and files/ generated by manim
* README.md: Fix a typo and change every `big_ol_pile_of_manim_imports`
	to `manimlib.imports`, which is the official substitution
* code/*.py: Change all `big_ol_pile_of_manim_imports` to
	`manimlib.imports` in order to fix #2